### PR TITLE
update for Julia 1.10

### DIFF
--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -642,6 +642,18 @@ if VERSION >= v"1.4.0-DEV.304"
 end
 
 let line = @__LINE__, file = @__FILE__
+    @static if VERSION >= v"1.10.0-DEV.873"
+    @eval (@__MODULE__) begin
+        function $Cassette.overdub($OVERDUB_CONTEXT_NAME::$Cassette.Context, $OVERDUB_ARGUMENTS_NAME...)
+            $(Expr(:meta, :generated_only))
+            $(Expr(:meta, :generated, __overdub_generator__))
+        end
+        function $Cassette.recurse($OVERDUB_CONTEXT_NAME::$Cassette.Context, $OVERDUB_ARGUMENTS_NAME...)
+            $(Expr(:meta, :generated_only))
+            $(Expr(:meta, :generated, __overdub_generator__))
+        end
+    end
+    else
     @eval (@__MODULE__) begin
         function $Cassette.overdub($OVERDUB_CONTEXT_NAME::$Cassette.Context, $OVERDUB_ARGUMENTS_NAME...)
             $(Expr(:meta, :generated_only))
@@ -669,6 +681,7 @@ let line = @__LINE__, file = @__FILE__
                         QuoteNode(Symbol(file)),
                         true)))
         end
+    end
     end
 end
 

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -118,7 +118,11 @@ function reflect(@nospecialize(sigtypes::Tuple), world::UInt = get_world_counter
     method_instance === nothing && return nothing
     method_signature = method.sig
     static_params = Any[raw_static_params...]
-    code_info = Core.Compiler.retrieve_code_info(method_instance)
+    @static if VERSION >= v"1.10.0-DEV.873"
+        code_info = Core.Compiler.retrieve_code_info(method_instance, world)
+    else
+        code_info = Core.Compiler.retrieve_code_info(method_instance)
+    end
     isa(code_info, CodeInfo) || return nothing
     code_info = copy_code_info(code_info)
     verbose_lineinfo!(code_info, S)


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/48766 makes it so `retrieve_code_info` takes in a worldage, and dramatically simplifies construction of the special IR level generated functions.